### PR TITLE
fix: keep blog content visible without JavaScript

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -69,7 +69,13 @@ const visibleMetrics = visibleOperationalMetrics(frontmatter.metrics);
     </header>
     
     <!-- Article content -->
-    <article class="animate-on-scroll stagger-2">
+    <!--
+      Article content must remain visible without JavaScript. Previously this used
+      `animate-on-scroll`, whose base CSS sets opacity to 0 until the client-side
+      observer runs. When that observer did not initialize, every post rendered
+      an empty body.
+    -->
+    <article>
       <Prose>
         <slot />
       </Prose>


### PR DESCRIPTION
## Summary

Keep Markdown article bodies visible even when the client-side scroll observer does not initialize.

## Root cause

`animate-on-scroll` applies `opacity: 0` by default. The shared blog layout applied that class to every article body, so a failed or delayed observer left posts blank beneath their headers.

## Impact

The fix applies to the 350 populated posts that share `BlogLayout.astro`, including the local AI infrastructure article.

## Validation

- `git diff --check`
- Local `astro build` was started but did not progress past initialization in this environment; no compiler error was emitted before it was stopped.
