### PR TITLE
fix: align blog routes and AI labels

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,9 +1,8 @@
 ---
 import Section from "../components/common/Section.astro";
+import fs from "node:fs/promises";
 import type { ArticleFrontmatter } from "../lib/types";
-import {
-  processArticleDate,
-} from "../lib/utils";
+import { getMarkdownBodyTextLength, processArticleDate } from "../lib/utils";
 import { editorialLabels, formatEditorialSource, normalizeEditorial, visibleOperationalMetrics } from "../lib/editorial";
 import { GLOBAL } from "../lib/variables";
 import type { MarkdownLayoutProps } from "astro";
@@ -13,7 +12,14 @@ import Layout from "./Layout.astro";
 type Props = MarkdownLayoutProps<ArticleFrontmatter>;
 
 const { frontmatter: rawFrontmatter } = Astro.props;
-const frontmatter = normalizeEditorial(rawFrontmatter);
+const articlePath = `${process.cwd()}/src/pages${decodeURIComponent(Astro.url.pathname)}.md`;
+const articleContent = await fs.readFile(articlePath, "utf8").catch(() => undefined);
+const bodyTextLength = getMarkdownBodyTextLength(articleContent);
+const isShortAiPost = bodyTextLength >= 40 && bodyTextLength < 300;
+const frontmatter = normalizeEditorial({
+  ...rawFrontmatter,
+  source: isShortAiPost ? "agentic" : rawFrontmatter.source,
+});
 const articleDate = processArticleDate(frontmatter.timestamp);
 const sourceUrl = new URL(Astro.url.pathname, GLOBAL.rootUrl).href;
 const lang = frontmatter.lang ?? "es";

--- a/src/lib/contentLoaders.ts
+++ b/src/lib/contentLoaders.ts
@@ -28,8 +28,10 @@ const slugFromFile = (file?: string) => cleanSlug(file?.split("/").pop());
 const SHORT_AI_POST_MIN_LENGTH = 40;
 const SHORT_AI_POST_MAX_LENGTH = 300;
 
-const mapArticle = (data: { frontmatter: ArticleFrontmatter; file?: string; content?: string }) => {
-  const slug = cleanSlug(data.frontmatter.filename) ?? slugFromFile(data.file) ?? data.frontmatter.filename;
+const mapArticle = (data: { frontmatter: ArticleFrontmatter; file?: string; url?: string; content?: string }) => {
+  // Astro routes Markdown files from their physical filename. Prefer that
+  // value over a legacy frontmatter filename, which can differ by _ vs -.
+  const slug = cleanSlug(data.url) ?? slugFromFile(data.file) ?? cleanSlug(data.frontmatter.filename) ?? data.frontmatter.filename;
   const shortDescription = getShortDescription(data.frontmatter.description);
   const bodyTextLength = getMarkdownBodyTextLength(data.content);
   const isShortAiPost =

--- a/src/pages/blog/[...slug].ts
+++ b/src/pages/blog/[...slug].ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { APIRoute } from "astro";
+
+const postsDirectory = path.join(process.cwd(), "src/pages/blog");
+
+export async function getStaticPaths() {
+  const files = await fs.readdir(postsDirectory);
+  const physicalSlugs = new Set(
+    files.filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, "")),
+  );
+  const legacySlugs = new Set<string>();
+  const paths: { params: { slug: string }; props: { target: string } }[] = [];
+
+  for (const file of files.filter((name) => name.endsWith(".md"))) {
+    const physicalSlug = file.replace(/\.md$/, "");
+    const source = await fs.readFile(path.join(postsDirectory, file), "utf8");
+    const legacySlug = source.match(/^filename:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]?.trim();
+
+    if (!legacySlug || legacySlug === physicalSlug || physicalSlugs.has(legacySlug) || legacySlugs.has(legacySlug)) continue;
+
+    legacySlugs.add(legacySlug);
+    paths.push({ params: { slug: legacySlug }, props: { target: `/blog/${physicalSlug}` } });
+  }
+
+  return paths;
+}
+
+export const GET: APIRoute = ({ props }) =>
+  new Response(null, {
+    status: 301,
+    headers: { Location: props.target },
+  });

--- a/src/pages/blog/[...slug].ts
+++ b/src/pages/blog/[...slug].ts
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
     files.filter((name) => name.endsWith(".md")).map((name) => name.replace(/\.md$/, "")),
   );
   const legacySlugs = new Set<string>();
-  const paths: { params: { slug: string }; props: { target: string } }[] = [];
+  const paths: { params: { slug: string } }[] = [];
 
   for (const file of files.filter((name) => name.endsWith(".md"))) {
     const physicalSlug = file.replace(/\.md$/, "");
@@ -20,14 +20,27 @@ export async function getStaticPaths() {
     if (!legacySlug || legacySlug === physicalSlug || physicalSlugs.has(legacySlug) || legacySlugs.has(legacySlug)) continue;
 
     legacySlugs.add(legacySlug);
-    paths.push({ params: { slug: legacySlug }, props: { target: `/blog/${physicalSlug}` } });
+    paths.push({ params: { slug: legacySlug } });
   }
 
   return paths;
 }
 
-export const GET: APIRoute = ({ props }) =>
-  new Response(null, {
-    status: 301,
-    headers: { Location: props.target },
-  });
+export const GET: APIRoute = async ({ params }) => {
+  const requestedSlug = params.slug;
+  const files = await fs.readdir(postsDirectory);
+
+  for (const file of files.filter((name) => name.endsWith(".md"))) {
+    const source = await fs.readFile(path.join(postsDirectory, file), "utf8");
+    const legacySlug = source.match(/^filename:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]?.trim();
+
+    if (legacySlug === requestedSlug) {
+      return new Response(null, {
+        status: 301,
+        headers: { Location: `/blog/${file.replace(/\.md$/, "")}` },
+      });
+    }
+  }
+
+  return new Response(null, { status: 404 });
+};


### PR DESCRIPTION
## Summary

Fixes legacy blog links that used frontmatter slugs instead of Astro’s file-based routes. Individual post pages now apply the same short-post AI classification as the listing.

## Validation

- Confirmed the affected article content exists at its physical route.
- `git diff --check`.